### PR TITLE
addressed output format and typos found in days array

### DIFF
--- a/Chapter-3/dynamic_christmas_carol/result.txt
+++ b/Chapter-3/dynamic_christmas_carol/result.txt
@@ -86,7 +86,7 @@
    two turtle doves,
    and a partridge in a pear tree.
 
-   On the twelvth day of Christmas, my true love gave to me
+   On the twelfth day of Christmas, my true love gave to me
    twelve drummers drumming,
    eleven pipers piping,
    ten lords a-leaping,

--- a/Chapter-3/dynamic_christmas_carol/src/main.rs
+++ b/Chapter-3/dynamic_christmas_carol/src/main.rs
@@ -6,7 +6,7 @@ fn verse_printer() {
     const NUM_DAYS: i32 = 12;
 
     const DAY_ARRAY: [&str; 12] = [ "first", "second", "third", "fourth", "fifth", "sixth", "seventh", "eigth", "ninth",
-                                 "tenth", "eleventh", "twelvth"];
+                                 "tenth", "eleventh", "twelfth"];
 
     const GIFT_ARRAY: [&str; 12] = [  "a partridge in a pear tree.",
                                         "two turtle doves,",


### PR DESCRIPTION
addressed typos and moved output file format to .txt